### PR TITLE
Infraestrutura: preparar imagem e stack Traefik

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Diretórios e arquivos desnecessários para a imagem
+.git
+.gitignore
+.mcp.json
+.claude
+.vscode
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.eggs
+*.egg-info
+htmlcov
+coverage.xml
+.tests
+pytest.ini
+*.log
+.DS_Store
+.env
+.env.*
+.idea
+run.sh
+run-ui.sh
+streamlit_app.py
+tests

--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,42 @@
-# Configurações da API Astrológica
+# Configuracoes da API Astrologica
 
-# Nome da aplicação
-APP_NAME="API Astrológica"
+# Nome da aplicacao
+APP_NAME="API Astrologica"
 
-# Versão da API
+# Versao da API
 VERSION="1.0.0"
 
-# Modo debug (true para desenvolvimento, false para produção)
+# Tipo de ambiente (dev, staging, prod)
+ENV_TYPE="dev"
+
+# Modo debug (true para desenvolvimento, false para producao)
 DEBUG=true
 
-# Timezone padrão para cálculos
+# Timezone padrao para calculos
 DEFAULT_TIMEZONE="America/Sao_Paulo"
 
-# Username para GeoNames (opcional - para busca automática de coordenadas)
+# Username para GeoNames (opcional - para busca automatica de coordenadas)
 # Registre-se em https://www.geonames.org/login
 GEONAMES_USERNAME=""
 
-# Configurações do servidor (para uvicorn)
+# Configuracoes do servidor (para uvicorn)
 HOST="0.0.0.0"
 PORT=8000
 WORKERS=1
 
-# Configurações de logging
+# Caminhos base para publicacao atras de proxies (Traefik/Portainer)
+API_BASE_PATH=""
+UI_BASE_PATH="/ui"
+
+# Configuracoes de logging
 LOG_LEVEL="INFO"
+LOG_FORMAT="text" # valores aceitos: text, json
+
+# Observabilidade
+ENABLE_METRICS=false
+METRICS_PATH="/metrics"
+
+# Traefik / Portainer
+TRAEFIK_ENTRYPOINT="websecure"
+TRAEFIK_DOMAIN="api.exemplo.com"
+TRAEFIK_ACME_EMAIL="contato@exemplo.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,49 @@
-FROM python:3.11-slim
+# Etapa de build: instala dependencias em um ambiente isolado
+FROM python:3.11-slim AS builder
 
-WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
 
 COPY . .
 
-RUN pip install --no-cache-dir -e .
+RUN python -m venv /opt/venv \
+    && . /opt/venv/bin/activate \
+    && pip install --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir .
+
+# Etapa final: imagem enxuta apenas com runtime
+FROM python:3.11-slim AS runner
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /app
+
+COPY --from=builder /opt/venv /opt/venv
+COPY app ./app
+COPY uv.lock ./uv.lock
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+COPY API_DOCUMENTATION.md README.md ./
+
+RUN chmod +x docker-entrypoint.sh
+
+USER app
 
 EXPOSE 8000
 
-CMD ["gunicorn", "-b", "0.0.0.0:8000", "app.main:app"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD curl -f "http://127.0.0.1:${PORT:-8000}${API_BASE_PATH:-/api}/v1/health/" || exit 1
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,6 +6,13 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
+class LoggingFormats:
+    """Constantes com formatos de logging aceitos."""
+
+    TEXT = "text"
+    JSON = "json"
+
+
 class Settings(BaseSettings):
     """Configurações da aplicação."""
 
@@ -13,6 +20,20 @@ class Settings(BaseSettings):
     version: str = Field(default="1.0.0", description="Versão da API")
     debug: bool = Field(default=False, description="Modo debug")
     env_type: str = Field(default="dev", description="Tipo do ambiente")
+    host: str = Field(default="0.0.0.0", description="Host para bind do servidor")
+    port: int = Field(default=8000, description="Porta padrão do servidor")
+    workers: int = Field(default=1, description="Número de workers do servidor")
+    api_base_path: str = Field(
+        default="",
+        description="Base path quando publicado atrás de proxy (usar Traefik strip-prefix)"
+    )
+    ui_base_path: str = Field(default="/ui", description="Base path da interface web")
+    enable_metrics: bool = Field(default=False, description="Habilita endpoint de métricas Prometheus")
+    metrics_path: str = Field(default="/metrics", description="Caminho para métricas Prometheus")
+    traefik_entrypoint: str = Field(default="websecure", description="Entrypoint padrão do Traefik")
+    traefik_domain: str = Field(default="", description="Domínio público usado pelo Traefik")
+    log_level: str = Field(default="INFO", description="Nível de logging")
+    log_format: str = Field(default=LoggingFormats.TEXT, description="Formato de logging: text ou json")
 
     # Configurações de localização padrão
     default_timezone: str = Field(default="America/Sao_Paulo", description="Timezone padrão")

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,0 +1,52 @@
+"""Utilitários para configuração de logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from .config import LoggingFormats
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Formata logs no padrão JSON simples compatível com agregadores."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        log_record: Dict[str, Any] = {
+            "level": record.levelname,
+            "time": self.formatTime(record, self.datefmt),
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_record, ensure_ascii=True)
+
+
+def configure_logging(level: str, fmt: str) -> None:
+    """Configura logging global considerando nível e formato."""
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+
+    try:
+        log_level = getattr(logging, level.upper())
+    except AttributeError:
+        log_level = logging.INFO
+
+    if fmt == LoggingFormats.JSON:
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonLogFormatter(datefmt="%Y-%m-%dT%H:%M:%S%z"))
+        root_logger.setLevel(log_level)
+        root_logger.addHandler(handler)
+    else:
+        logging.basicConfig(
+            level=log_level,
+            format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+
+
+__all__ = ["configure_logging"]

--- a/deploy/portainer-stack.yml
+++ b/deploy/portainer-stack.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  api:
+    image: registry.example.com/astrologer-api:latest
+    env_file:
+      - .env
+    deploy:
+      restart_policy:
+        condition: on-failure
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=reverse-proxy"
+      - "traefik.http.routers.astrologer-api.rule=Host(`${TRAEFIK_DOMAIN}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.astrologer-api.entrypoints=${TRAEFIK_ENTRYPOINT}"
+      - "traefik.http.routers.astrologer-api.tls.certresolver=le"
+      - "traefik.http.routers.astrologer-api.middlewares=api-strip"
+      - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
+      - "traefik.http.routers.astrologer-ui.rule=Host(`${TRAEFIK_DOMAIN}`) && PathPrefix(`/ui`)"
+      - "traefik.http.routers.astrologer-ui.entrypoints=${TRAEFIK_ENTRYPOINT}"
+      - "traefik.http.routers.astrologer-ui.tls.certresolver=le"
+      - "traefik.http.routers.astrologer-ui.middlewares=ui-strip"
+      - "traefik.http.middlewares.ui-strip.stripprefix.prefixes=/ui"
+      - "traefik.http.services.astrologer-api.loadbalancer.server.port=8000"
+    networks:
+      - reverse-proxy
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - redis-data:/data
+    networks:
+      - reverse-proxy
+
+networks:
+  reverse-proxy:
+    external: true
+
+volumes:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+version: "3.9"
+
+services:
+  api:
+    image: ${API_IMAGE:-astrologer-api:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      HOST: 0.0.0.0
+      PORT: ${PORT:-8000}
+      WORKERS: ${WORKERS:-2}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      API_BASE_PATH: ""
+    depends_on:
+      - redis
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=reverse-proxy"
+      - "traefik.http.routers.astrologer-api.rule=Host(`${TRAEFIK_DOMAIN:-api.exemplo.com}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.astrologer-api.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}"
+      - "traefik.http.routers.astrologer-api.tls.certresolver=le"
+      - "traefik.http.routers.astrologer-api.middlewares=api-strip"
+      - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
+      - "traefik.http.routers.astrologer-ui.rule=Host(`${TRAEFIK_DOMAIN:-api.exemplo.com}`) && PathPrefix(`/ui`)"
+      - "traefik.http.routers.astrologer-ui.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}"
+      - "traefik.http.routers.astrologer-ui.tls.certresolver=le"
+      - "traefik.http.routers.astrologer-ui.middlewares=ui-strip"
+      - "traefik.http.middlewares.ui-strip.stripprefix.prefixes=/ui"
+      - "traefik.http.services.astrologer-api.loadbalancer.server.port=8000"
+    networks:
+      - reverse-proxy
+
+  traefik:
+    image: traefik:v2.10
+    restart: unless-stopped
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --certificatesresolvers.le.acme.tlschallenge=true
+      - --certificatesresolvers.le.acme.email=${TRAEFIK_ACME_EMAIL:-admin@example.com}
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - traefik-config:/etc/traefik
+      - traefik-letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - reverse-proxy
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - redis-data:/data
+    networks:
+      - reverse-proxy
+
+networks:
+  reverse-proxy:
+    driver: bridge
+
+volumes:
+  traefik-config:
+  traefik-letsencrypt:
+  redis-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+START_TIME=$(date +%Y-%m-%dT%H:%M:%S%z)
+echo "[$START_TIME] Starting Astrologer API container"
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-8000}
+WORKERS=${WORKERS:-1}
+API_BASE_PATH=${API_BASE_PATH:-/api}
+LOG_LEVEL=${LOG_LEVEL:-info}
+LOWER_LOG_LEVEL=$(printf "%s" "$LOG_LEVEL" | tr '[:upper:]' '[:lower:]')
+
+echo "[INFO] Host: $HOST | Port: $PORT | Workers: $WORKERS | Base path: $API_BASE_PATH"
+
+# Basic dependency check before booting the server
+if ! python -c "import kerykeion" >/dev/null 2>&1; then
+  echo "[ERROR] Kerykeion library not found."
+  exit 1
+fi
+
+echo "[INFO] Dependencies validated. Starting Uvicorn..."
+
+exec uvicorn app.main:app \
+  --host "$HOST" \
+  --port "$PORT" \
+  --workers "$WORKERS" \
+  --proxy-headers \
+  --forwarded-allow-ips='*' \
+  --log-level "$LOWER_LOG_LEVEL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "kerykeion>=4.15.0",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
+    "prometheus-client>=0.18.0",
 ]
 
 [project.optional-dependencies]
@@ -20,7 +21,14 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.7.0",
 ]
+ui = [
+    "streamlit>=1.28.0",
+    "requests>=2.31.0",
+]
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["app"]


### PR DESCRIPTION
## Resumo\n- refatora Dockerfile em duas etapas com entrypoint uvicorn e healthcheck\n- adiciona docker-compose e stack Portainer com Traefik e Redis opcional\n- expande configuracao (.env, settings, logging, metrics) e documentacao de deploy\n\n## Referencias\n- Closes #2\n\n## Deploy\n- docker compose up -d\n\n## Testes\n- uv run --extra test pytest *(falha: suite usa FastAPI.test_client; atualizar testes para TestClient)*